### PR TITLE
files - use `fs.promises.rename` for `rimraf` to skip `graceful-fs`

### DIFF
--- a/src/vs/base/node/pfs.ts
+++ b/src/vs/base/node/pfs.ts
@@ -56,7 +56,15 @@ async function rimrafMove(path: string): Promise<void> {
 	try {
 		const pathInTemp = randomPath(tmpdir());
 		try {
-			await Promises.rename(path, pathInTemp);
+			// Intentionally using `fs.promises` here to skip
+			// the patched graceful-fs method that can result
+			// in very long running `rename` calls when the
+			// folder is locked by a file watcher. We do not
+			// really want to slow down this operation more
+			// than necessary and we have a fallback to delete
+			// via unlink.
+			// https://github.com/microsoft/vscode/issues/139908
+			await fs.promises.rename(path, pathInTemp);
 		} catch (error) {
 			return rimrafUnlink(path); // if rename fails, delete without tmp dir
 		}


### PR DESCRIPTION
We do not really want the move operation to hang for a long time when the folder is locked on Windows.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #
